### PR TITLE
Remove certain unicode symbols from video menu

### DIFF
--- a/VideoPlayer/UI/VideoMenu/VideoMenu.cs
+++ b/VideoPlayer/UI/VideoMenu/VideoMenu.cs
@@ -182,6 +182,12 @@ namespace MusicVideoPlayer
             LoadVideoSettings(videoData, false);
         }
 
+        private string FilterEmoji(string text)
+        {
+            //see https://stackoverflow.com/a/28025891 for an explanation
+            return Regex.Replace(text, @"\p{Cs}", "");
+        }
+        
         public void LoadVideoSettings(VideoData videoData, bool checkForVideo = true)
         {
             // Plugin.logger.Info($"Stopping Preview");
@@ -201,8 +207,8 @@ namespace MusicVideoPlayer
             if (videoData != null)
             {
                 Plugin.logger.Info($"Loading: {videoData?.title} for level: {selectedLevel?.songName}");
-                videoTitleText.text = $"[{selectedVideo.duration}] {selectedVideo.title}";
-                currentVideoDescriptionText.text = selectedVideo.description;
+                videoTitleText.text = $"[{selectedVideo.duration}] {FilterEmoji(selectedVideo.title)}";
+                currentVideoDescriptionText.text = FilterEmoji(selectedVideo.description);
                 currentVideoOffsetText.text = selectedVideo.offset.ToString();
                 EnableButtons(true);
             }


### PR DESCRIPTION
The game crashes when downloading videos with certain unicode symbols (probably mainly emoji) in the description. This makes sure to remove those before displaying the text.

Fixes #31