### PR TITLE
Updated for Beat Saber 1.12.2

### DIFF
--- a/VideoPlayer/UI/VideoMenu/VideoMenu.cs
+++ b/VideoPlayer/UI/VideoMenu/VideoMenu.cs
@@ -52,8 +52,6 @@ namespace MusicVideoPlayer
 
         [UIComponent("video-title")] private TextMeshProUGUI videoTitleText;
 
-        [UIComponent("current-video-title")] private TextMeshProUGUI currentVideoTitleText;
-
         [UIComponent("current-video-description")]
         private TextMeshProUGUI currentVideoDescriptionText;
 
@@ -117,8 +115,8 @@ namespace MusicVideoPlayer
         [UIParams] private BSMLParserParams parserParams;
 
         private Vector3 videoPlayerDetailScale = new Vector3(0.57f, 0.57f, 1f);
-
-        private Vector3 videoPlayerDetailPosition = new Vector3(-2.35f, 1.5f, 1.3f);
+        private Vector3 videoPlayerDetailPosition = new Vector3(-2.35f, 1.22f, 1.0f);
+        private Vector3 videoPlayerDetailRotation = new Vector3(0f, 295f, 0f);
 
         private VideoData selectedVideo;
 
@@ -203,9 +201,7 @@ namespace MusicVideoPlayer
             if (videoData != null)
             {
                 Plugin.logger.Info($"Loading: {videoData?.title} for level: {selectedLevel?.songName}");
-                videoTitleText.text = selectedVideo.title;
-                currentVideoTitleText.text =
-                    $"[{selectedVideo.duration}] {selectedVideo.title} by {selectedVideo.author}";
+                videoTitleText.text = $"[{selectedVideo.duration}] {selectedVideo.title}";
                 currentVideoDescriptionText.text = selectedVideo.description;
                 currentVideoOffsetText.text = selectedVideo.offset.ToString();
                 EnableButtons(true);
@@ -225,7 +221,6 @@ namespace MusicVideoPlayer
         public void ClearSettings()
         {
             videoTitleText.text = "No Video";
-            currentVideoTitleText.text = "NO VIDEO SET";
             currentVideoDescriptionText.text = "";
             currentVideoOffsetText.text = "N/A";
             EnableButtons(false);
@@ -246,7 +241,6 @@ namespace MusicVideoPlayer
             selectedVideo = null;
 
             videoTitleText.text = "No Video";
-            currentVideoTitleText.text = "NO VIDEO SET";
             currentVideoDescriptionText.text = "";
             currentVideoOffsetText.text = "N/A";
             EnableButtons(false);
@@ -314,7 +308,7 @@ namespace MusicVideoPlayer
                 {
                     ScreenManager.Instance.SetScale(videoPlayerDetailScale);
                     ScreenManager.Instance.SetPosition(videoPlayerDetailPosition);
-                    ScreenManager.Instance.SetRotation(videoDetailsViewRect.transform.eulerAngles);
+                    ScreenManager.Instance.SetRotation(videoPlayerDetailRotation);
                 }
 
                 LoadVideoSettings(selectedVideo);
@@ -438,7 +432,11 @@ namespace MusicVideoPlayer
                 if (request.isNetworkError || request.isHttpError)
                     Plugin.logger.Debug(request.error);
                 else
-                    item.icon = ((DownloadHandlerTexture) request.downloadHandler).texture;
+                {
+                    var tex = ((DownloadHandlerTexture) request.downloadHandler).texture;
+                    item.icon = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), Vector2.one * 0.5f, 100, 1);
+                }
+
                 videoCells.Add(item);
             }
 
@@ -1390,7 +1388,7 @@ namespace MusicVideoPlayer
 
         #region Events
 
-        private void MissionSelectionDidActivate(bool firstActivation, ViewController.ActivationType activationType)
+        private void MissionSelectionDidActivate(bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling)
         {
             selectedVideo = null;
             selectedLevel = null;

--- a/VideoPlayer/Views/video-menu.bsml
+++ b/VideoPlayer/Views/video-menu.bsml
@@ -1,58 +1,55 @@
 <bg id='root-object' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation="https://monkeymanboy.github.io/BSML-Docs https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd">
   <bg id='video-details'>
-    <vertical child-control-height='false'>
-    <horizontal pad='3' preferred-width='120' horizontal-fit='PreferredSize'>
-      <button id='prev-video' pref-width='7' preferred-height='5' on-click='prev-video-action' text='🢤'/>
-      <text font-size='4' id='video-title' align='Center' overflow-mode='Ellipsis' text='No Video'></text>
-      <button id='next-video' pref-width='7' preferred-height='5' on-click='next-video-action' text='➩'/>
-    </horizontal>
-    <horizontal pad='5'>
-      <vertical child-control-width='false' horizontal-fit='PreferredSize' vertical-fit='PreferredSize'>
-        <vertical id='current-video-player' pref-height='15' pref-width='48' pad-left='80'/>
-        <vertical pad-top='0' preferred-width='80'>
-          <text id='current-video-title' text="No Title" font-align='Center' font-size='3' overflow-mode='Ellipsis'></text>
-        </vertical>
-        <vertical preferred-width='80' preferred-height='20'>
-          <text id='current-video-description' text="No Description" word-wrapping='true' font-align='TopLeft' overflow-mode='Ellipsis' font-size='2'></text>
-        </vertical>
-      </vertical>
-      <vertical vertical-fit='PreferredSize' horizontal-fit='PreferredSize' spacing='0' pad-bottom='30'>
-        <horizontal pad-top='0' spacing='3' horizontal-fit='PreferredSize'>
-          <button id='offset-decrease-button' hover-hint='Starts Video Later' text='-' pad='0' on-click='on-offset-decrease-action' all-uppercase='false' pref-width='5' pref-height='5'/>
-          <text id='current-video-offset' text="0" font-size='4' align='Center'></text>
-          <button id='offset-increase-button' hover-hint='Starts Video Earlier' text='+' pad='0' on-click='on-offset-increase-action' all-uppercase='false' pref-width='5' pref-height='5'/>
+    <vertical>
+        <horizontal pad='5' font-size='3' preferred-width='120' horizontal-fit='PreferredSize'>
+          <button id='prev-video' on-click='prev-video-action' text='🢤'/>
+          <text id='video-title' font-size='4' align='Center' overflow-mode='Ellipsis' text='No Video'></text>
+          <button id='next-video' on-click='next-video-action' text='➩'/>
         </horizontal>
-        <button id='offset-magnitude-button' text='+100' on-click='on-offset-magnitude-action' preferred-height='5' font-size='3'/>
-        <button id='guess-offset' text='Guess Offset' on-click='on-guess-offset-action' preferred-height='5' font-size='3' interactable='false'/>
-        <button id='cut-video' text='Auto-Cut Video' on-click='on-cut-video-action' preferred-height='5' font-size='3' interactable='false'/>
-        <button id='reset-guess' text='Reset Guess/Cut' on-click='on-reset-guess-action' preferred-height='5' font-size='3' interactable='true'/>
-        <!-- <button id='looping-button' text='Loop' on-click='on-looping-action' preferred-height='5' font-size='3'/> -->
-        <text id='download-state-text' text='Download Progress: Complete' align='Center' font-size='3'/>
-      </vertical>
-    </horizontal>
+        <horizontal pad-top='10'>
+          <vertical child-control-width='false' horizontal-fit='PreferredSize' vertical-fit='PreferredSize'>
+            <vertical id='current-video-player' preferred-height='16' preferred-width='48' pad-left='80'/>
+            <vertical preferred-width='80' preferred-height='10'>
+              <text id='current-video-description' text="No Description" word-wrapping='true' font-align='TopLeft' overflow-mode='Ellipsis' font-size='1.5'></text>
+            </vertical>
+          </vertical>
+          <vertical pad-top='2' vertical-fit='PreferredSize' horizontal-fit='PreferredSize' spacing='0' pad-bottom='30'>
+            <horizontal pad-top='0' spacing='3' horizontal-fit='PreferredSize'>
+              <button id='offset-decrease-button' font-size='3' hover-hint='Starts Video Later' text='-' pad='1' on-click='on-offset-decrease-action' all-uppercase='false'/>
+              <text id='current-video-offset' text="0" font-size='4' align='Center'></text>
+              <button id='offset-increase-button' font-size='3' hover-hint='Starts Video Earlier' text='+' pad='1' on-click='on-offset-increase-action' all-uppercase='false'/>
+            </horizontal>
+            <button id='offset-magnitude-button' text='+100' on-click='on-offset-magnitude-action' font-size='3'/>
+            <button id='guess-offset' text='Guess Offset' on-click='on-guess-offset-action' font-size='3' interactable='false'/>
+            <button id='cut-video' text='Auto-Cut Video' on-click='on-cut-video-action' font-size='3' interactable='false'/>
+            <button id='reset-guess' text='Reset Guess/Cut' on-click='on-reset-guess-action' font-size='3' interactable='true'/>
+            <!-- <button id='looping-button' text='Loop' on-click='on-looping-action' font-size='3'/> -->
+            <text id='download-state-text' text='Download Progress: Complete' align='Center' font-size='3'/>
+          </vertical>
+        </horizontal>
+        <horizontal pad-top='-6'>
+          <button id='delete-button' text='Delete Config' on-click='on-delete-action'/>
+          <button id='delete-video-button' text='Delete Video' on-click='on-delete-video-action'/>
+          <button id='add-button' text='Add Config' on-click='on-add-action' interactable='false'/>
+          <button id='preview-button' text='Preview' on-click='on-preview-action'/>
+          <button id='search-button' text='Search' on-click='on-search-action'/>
+        </horizontal>
     </vertical>
-    <bottom-button-panel pad-top='3'>
-      <button id='delete-button' text='Delete Config' on-click='on-delete-action'/>
-      <button id='delete-video-button' text='Delete Video' on-click='on-delete-video-action'/>
-      <button id='add-button' text='Add Config' on-click='on-add-action' interactable='false'/>
-      <button id='preview-button' text='Preview' on-click='on-preview-action'/>
-      <button id='search-button' text='Search' on-click='on-search-action'/>
-    </bottom-button-panel>
   </bg>
   <bg id='video-search-results'>
-    <vertical pad-bottom='8' preferred-width='100'>
-      <page-button click-event='video-list#PageUp' direction='Up' pref-width='30' pref-height='5'/>
-      <list id='video-list' list-width='100' visible-cells='4' select-cell='on-select-cell'/>
-      <page-button click-event='video-list#PageDown' direction='Down' pref-width='30' pref-height='5'/>
-    </vertical>
-    <text id='search-results-loading' active='false' font-size='2' text='Loading Results...' align='Center' anchor-pos-y='5'/>
-    <modal-keyboard id='search-keyboard' on-enter='on-query' clear-on-open='false' show-event='show-keyboard'
-                    hide-event='hide-keyboard' move-to-center='true' click-off-closes='true'/>
-    <bottom-button-panel pad-top='3'>
-      <button text='Back' on-click='on-back-action'/>
-      <button id='download-button' text='Download' on-click='on-download-action'/>
-      <!-- <button id='download-by-id-button' text='Download' on-click='on-download-by-id-action'/> -->
-      <button id='refine-button' text='Refine' on-click='on-refine-action'/>
-    </bottom-button-panel>
+        <vertical pad-top='3' pad-bottom='8' preferred-width='100'>
+          <page-button click-event='video-list#PageUp' direction='Up' preferred-width='25' preferred-height='4'/>
+          <list pad-top='3' id='video-list' list-width='100' visible-cells='4' select-cell='on-select-cell'/>
+          <page-button click-event='video-list#PageDown' direction='Down' preferred-width='25' preferred-height='4'/>
+        </vertical>
+        <text id='search-results-loading' active='false' font-size='2' text='Loading Results...' align='Center' anchor-pos-y='5'/>
+        <modal-keyboard id='search-keyboard' on-enter='on-query' clear-on-open='false' show-event='show-keyboard'
+                        hide-event='hide-keyboard' move-to-center='true' click-off-closes='true'/>
+        <horizontal pad-top='50'>
+          <button text='Back' on-click='on-back-action'/>
+          <button id='download-button' text='Download' on-click='on-download-action'/>
+          <!-- <button id='download-by-id-button' text='Download' on-click='on-download-by-id-action'/> -->
+          <button id='refine-button' text='Refine' on-click='on-refine-action'/>
+        </horizontal>
   </bg>
 </bg>

--- a/VideoPlayer/manifest.json
+++ b/VideoPlayer/manifest.json
@@ -1,17 +1,17 @@
 ﻿{
   "$schema": "https://github.com/nike4613/BSIPA-MetadataFileSchema/master/Schema.json",
   "author": "Rolo, B_Rad15, rie-kumar",
-  "description": "Music Video Player is a mod that allows players to download and have a video play in sync with the music during a beat saber level (i.e. the songs music video, a dance video of for the song)",
-  "gameVersion": "1.11.1",
+  "description": "Music Video Player is a mod that allows players to download and have a video play in sync with the music during a beat saber level (i.e. the song's music video or a dance video for the song)",
+  "gameVersion": "1.12.2",
   "id": "Music Video Player",
   "name": "Music Video Player",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "features": [
 
   ],
   "dependsOn": {
-    "BS Utils": "^1.4.11",
-    "BeatSaberMarkupLanguage": "^1.3.4",
-    "BSIPA": "^4.0.5"
+    "BS Utils": "^1.5.0",
+    "BeatSaberMarkupLanguage": "^1.3.5",
+    "BSIPA": "^4.1.3"
   }
 }


### PR DESCRIPTION
I removed the video title below the preview player, since the title is already at the very top. This was necessary because otherwise the buttons below would clip into the new floor in the main menu. I prefixed the top title with the video duration so that information is not lost. 

I did not quite test every single function of the plugin, only the basics (downloading, previewing, deleting video, playing a song with a video).

**Known issues:** 

- Scrolling up in search menu does not work. The list overlaps the button somehow. Could not figure this one out yet.
- Search video button row uses an ugly `pad-top='50'` attribute, because wrapping the page in `<vertical>` causes the list to disappear. This was basically a workaround. Otherwise the button row was in the center of the list, not below it. There probably is a better way to align it properly.
- Ideally, the video menu should not be available in multiplayer and the player should not show up there.
- Maybe related to that, after I played a few multiplayer matches and then went into single player, videos would not play. The screen stayed black. Previewing videos in the main menu still worked. Have not tried to find steps to reproduce. May be unrelated to multiplayer.
- Button alignment in mod settings is a bit weird.
